### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+julia:
+  - 0.4
+  - 0.5
+  - nightly
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
   - sudo apt-get update -qq -y
-  - sudo apt-get install libstdc++6 libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.build("Sigma"); Pkg.checkout("AbstractDomains"); Pkg.checkout("Lens"); Pkg.test("Sigma")'
+  - sudo apt-get install libstdc++6 -y
+#script: # use the default script setting which is the same as the following but using tagged releases of dependencies
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.build("Sigma"); Pkg.checkout("AbstractDomains"); Pkg.checkout("Lens"); Pkg.test("Sigma")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ Docile
 AbstractDomains
 Lens
 MathProgBase
+Compat

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,7 @@ extension = @osx? "zip" : "tar.gz"
 file_name = "dReal-$version-$os_string-shared-libs.$extension"
 file_url = "https://github.com/zenna/dreal3/releases/download/v$version/$file_name"
 @show file_url
-deps_dir = joinpath(joinpath(Pkg.dir("Sigma"),"deps"))
+deps_dir = dirname(@__FILE__)
 prefix = joinpath(deps_dir,"usr")
 
 @show deps_dir

--- a/src/Sigma.jl
+++ b/src/Sigma.jl
@@ -1,7 +1,7 @@
 
 module Sigma
 
-deps_dir = joinpath(joinpath(Pkg.dir("Sigma"),"deps"))
+deps_dir = joinpath(dirname(@__FILE__),"..","deps")
 prefix = joinpath(deps_dir,"usr")
 src_dir = joinpath(prefix,"src")
 bin_dir = joinpath(prefix,"bin")


### PR DESCRIPTION
This allows installing the package elsewhere.

Modernize Travis - language: julia allows testing against more versions than the PPA

add Compat to REQUIRE explicitly instead of assuming it will be present as
an indirect dependency
